### PR TITLE
fix openai max token error

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,4 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True

--- a/client.go
+++ b/client.go
@@ -3,6 +3,8 @@ package xgpt3
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/fanchunke/xgpt3/conversation"
 	"github.com/rs/zerolog"
@@ -11,21 +13,23 @@ import (
 )
 
 const (
-	defaultMaxToken = 4000
-	defaultMaxTurn  = 10
-	defaultChannel  = "default"
+	defaultMaxCtxLength = 4097
+	defaultMaxTurn      = 10
+	defaultChannel      = "default"
+	questionPrefix      = "Q"
+	answerPrefix        = "A"
 )
 
 type Client struct {
 	*gogpt.Client
-	ch       conversation.Handler
-	maxToken int
-	maxTurn  int
-	logger   zerolog.Logger
+	ch           conversation.Handler
+	maxCtxLength int
+	maxTurn      int
+	logger       zerolog.Logger
 }
 
 func NewClient(client *gogpt.Client, ch conversation.Handler) *Client {
-	return &Client{Client: client, ch: ch, maxToken: defaultMaxToken, maxTurn: defaultMaxTurn, logger: log.Logger}
+	return &Client{Client: client, ch: ch, maxCtxLength: defaultMaxCtxLength, maxTurn: defaultMaxTurn, logger: log.Logger}
 }
 
 func (c *Client) WithMaxTurn(n int) *Client {
@@ -73,16 +77,20 @@ func (c *Client) CreateConversationCompletionWithChannel(
 }
 
 func (c *Client) preCompletion(ctx context.Context, request *gogpt.CompletionRequest, channel string) (*conversation.Session, *conversation.Message, error) {
-	session, newPrompt := c.buildSessionQuery(ctx, request.User, request.Prompt)
+	if request.MaxTokens >= c.maxCtxLength {
+		return nil, nil, fmt.Errorf("request.MaxTokens exceeded maximum context length")
+	}
 
-	var err error
-	// 如果没有 session，创建一个 session
-	if session == nil {
+	// 获取最近的 session。如果没有 session，创建一个 session。
+	session, err := c.ch.GetLatestActiveSession(ctx, request.User)
+	if err != nil {
 		session, err = c.ch.CreateSession(ctx, request.User)
 		if err != nil {
 			return nil, nil, fmt.Errorf("create session failed: %w", err)
 		}
 	}
+
+	newPrompt := c.buildSessionQuery(ctx, session, request)
 
 	// 保存用户消息
 	msg, err := c.ch.CreateMessage(ctx, session, request.User, channel, request.Prompt)
@@ -90,35 +98,57 @@ func (c *Client) preCompletion(ctx context.Context, request *gogpt.CompletionReq
 		return session, nil, fmt.Errorf("create message failed: %w", err)
 	}
 
-	if len(newPrompt) > c.maxToken {
-		newPrompt = string([]rune(newPrompt)[len(newPrompt)-c.maxToken:])
-	}
-
 	request.Prompt = newPrompt
+	c.logger.Debug().Msgf("Requested %d tokens (%d in your prompt; %d for the completion)", len(request.Prompt)+request.MaxTokens, len(request.Prompt), request.MaxTokens)
 	return session, msg, nil
 }
 
-func (c *Client) buildSessionQuery(ctx context.Context, userId, query string) (*conversation.Session, string) {
-	session, err := c.ch.GetLatestActiveSession(ctx, userId)
-	if err != nil {
-		fmt.Println(err)
-		return nil, query
+func (c *Client) buildSessionQuery(ctx context.Context, session *conversation.Session, request *gogpt.CompletionRequest) string {
+	if len(request.Prompt)+request.MaxTokens > c.maxCtxLength {
+		c.logger.Debug().Msgf("Requested %d tokens (%d in your prompt; %d for the completion), reduce prompt", len(request.Prompt)+request.MaxTokens, len(request.Prompt), request.MaxTokens)
+		return string([]rune(request.Prompt)[:c.maxCtxLength-request.MaxTokens])
 	}
-	msgs, err := c.ch.ListLatestMessagesWithSpouse(ctx, session, userId, c.maxTurn)
+
+	msgs, err := c.ch.ListLatestMessagesWithSpouse(ctx, session, request.User, c.maxTurn)
 	if err != nil {
-		return session, query
+		c.logger.Warn().Msgf("ListLatestMessagesWithSpouse failed: %s", err)
+		return request.Prompt
+	}
+
+	// 按照消息创建时间倒序排序
+	sort.Slice(msgs, func(i, j int) bool {
+		return msgs[i].CreatedAt.Sub(msgs[j].CreatedAt) > 0
+	})
+
+	query := fmt.Sprintf("%s: %s\n%s: ", questionPrefix, request.Prompt, answerPrefix)
+	pl := len(query)
+	selectedMsgs := []string{query}
+	for i := 0; i < len(msgs); i++ {
+		m := msgs[i]
+		prompt := ""
+		if m.FromUserID == request.User {
+			prompt += fmt.Sprintf("%s: %s\n", questionPrefix, m.Content)
+		} else {
+			prompt += fmt.Sprintf("%s: %s\n", answerPrefix, m.Content)
+		}
+
+		if len(prompt)+pl+request.MaxTokens <= c.maxCtxLength {
+			selectedMsgs = append([]string{prompt}, selectedMsgs...)
+			pl += len(prompt)
+		} else {
+			break
+		}
 	}
 
 	result := ""
-	for _, m := range msgs {
-		if m.FromUserID == userId {
-			result += fmt.Sprintf("Q: %s\n", m.Content)
-		} else {
-			result += fmt.Sprintf("A: %s\n", m.Content)
+	for i, p := range selectedMsgs {
+		if i == 0 && strings.HasPrefix(p, answerPrefix) {
+			continue
 		}
+		result += p
 	}
-	result += fmt.Sprintf("Q: %s\nA: ", query)
-	return session, result
+
+	return result
 }
 
 func (c *Client) postCompletion(ctx context.Context, request gogpt.CompletionRequest, response gogpt.CompletionResponse, session *conversation.Session, msg *conversation.Message, channel string) (*conversation.Message, error) {

--- a/conversation/ent/schema/session.go
+++ b/conversation/ent/schema/session.go
@@ -1,12 +1,13 @@
 package schema
 
 import (
+	"time"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
-	"time"
 )
 
 type Session struct {


### PR DESCRIPTION
#1 
https://github.com/fanchunke/chatgpt-wecom/issues/8

OpenAI 的接口中规定了上下文最长的 token 为 4097，这次改动主要修复传给接口的 prompt + maxTokens 小于 4097。